### PR TITLE
Constexpr-ify inplace_vector

### DIFF
--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -69,8 +69,9 @@ struct inplace_vector_type_based_storage {
   constexpr const T *begin() const { return elems.data(); }
 };
 
-// byte based storage is used for non-constexpr environment. Objects of type T are only
-// constructed when needed and they don't even have to be default constructible. 
+// byte based storage is used for non-constexpr environment. Objects of type T
+// are only constructed when needed and they don't even have to be default
+// constructible.
 //
 // Selecting this storage type implies: !std::is_trivial_v<T> and Capacity != 0
 template <typename T, std::size_t Capacity>

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -63,7 +63,7 @@ template <typename T, std::size_t Capacity>
 struct inplace_vector_type_based_storage {
   using array_type = If<!std::is_const_v<T>, std::array<T, Capacity>,
                         const std::array<std::remove_const_t<T>, Capacity>>;
-  array_type elems{};
+  array_type elems;
 
   constexpr T *begin() { return elems.data(); }
   constexpr const T *begin() const { return elems.data(); }

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -62,7 +62,7 @@ using inplace_vector_internal_size_type =
 template <typename T, std::size_t Capacity>
 struct inplace_vector_type_based_storage {
   using array_type = If<!std::is_const_v<T>, std::array<T, Capacity>,
-                        const std::array<std::remove_const_t<T>, Capacity>>;
+                        std::array<std::remove_const_t<T>, Capacity>>;
   array_type elems;
 
   constexpr T *begin() { return elems.data(); }

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -77,7 +77,7 @@ template <typename T, std::size_t Capacity>
 struct inplace_vector_bytes_based_storage {
   alignas(T) std::array<std::byte, Capacity * sizeof(T)> elems;
 
-  T *begin() { return std::launder(reinterpret_cast<const T *>(elems.data())); }
+  T *begin() { return std::launder(reinterpret_cast<T *>(elems.data())); }
   const T *begin() const {
     return std::launder(reinterpret_cast<const T *>(elems.data()));
   }
@@ -605,7 +605,8 @@ public:
 #else
     // Note: placement-new may not be constexpr friendly
     // Avoiding placement-new may allow inplace_vector to be constexpr friendly
-    auto final = ::new (end()) T(std::forward<Args>(args)...);
+    // cast to void* here to adapt to a const T
+    auto final = ::new ((void *)end()) T(std::forward<Args>(args)...);
 #endif
     this->change_size(1);
     return *final;

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -69,6 +69,7 @@ struct inplace_vector_type_based_storage {
   inplace_vector_array_type<T, Capacity> elems{};
 
   constexpr T *begin() { return elems.data(); }
+  constexpr const T *begin() const { return elems.data(); }
 };
 
 // byte array based storage is used for non-constexpr environment, where default
@@ -80,6 +81,9 @@ struct inplace_vector_bytes_based_storage {
   alignas(T) inplace_vector_array_type<std::byte, Capacity * sizeof(T)> elems;
 
   T *begin() { return std::launder(reinterpret_cast<const T *>(elems)); }
+  const T *begin() const {
+    return std::launder(reinterpret_cast<const T *>(elems));
+  }
 };
 
 //  Base class for inplace_vector

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -69,8 +69,8 @@ struct inplace_vector_type_based_storage {
   constexpr const T *begin() const { return elems.data(); }
 };
 
-// byte array based storage is used for non-constexpr environment, where default
-// initialization may not be available.
+// byte based storage is used for non-constexpr environment. Objects of type T are only
+// constructed when needed and they don't even have to be default constructible. 
 //
 // Selecting this storage type implies: !std::is_trivial_v<T> and Capacity != 0
 template <typename T, std::size_t Capacity>

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -69,7 +69,6 @@ struct inplace_vector_type_based_storage {
   inplace_vector_array_type<T, Capacity> elems{};
 
   constexpr T *begin() { return elems.data(); }
-  constexpr const T *begin() const { return elems.data(); }
 };
 
 // byte array based storage is used for non-constexpr environment, where default
@@ -81,9 +80,6 @@ struct inplace_vector_bytes_based_storage {
   alignas(T) inplace_vector_array_type<std::byte, Capacity * sizeof(T)> elems;
 
   T *begin() { return std::launder(reinterpret_cast<const T *>(elems)); }
-  const T *begin() const {
-    return std::launder(reinterpret_cast<const T *>(elems));
-  }
 };
 
 //  Base class for inplace_vector

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -56,17 +56,14 @@ using inplace_vector_internal_size_type =
           If<Capacity <= std::numeric_limits<uint32_t>::max(), uint32_t,
              uint64_t>>>;
 
-template <typename T, std::size_t Capacity>
-using inplace_vector_array_type =
-    If<!std::is_const_v<T>, std::array<T, Capacity>,
-       const std::array<std::remove_const_t<T>, Capacity>>;
-
 // array based storage is used so that we can satisfy constexpr requirement
 //
 // Selecting this storage type implies: std::is_trivial_v<T> or Capacity = 0
 template <typename T, std::size_t Capacity>
 struct inplace_vector_type_based_storage {
-  inplace_vector_array_type<T, Capacity> elems{};
+  using array_type = If<!std::is_const_v<T>, std::array<T, Capacity>,
+                        const std::array<std::remove_const_t<T>, Capacity>>;
+  array_type elems{};
 
   constexpr T *begin() { return elems.data(); }
   constexpr const T *begin() const { return elems.data(); }
@@ -78,11 +75,11 @@ struct inplace_vector_type_based_storage {
 // Selecting this storage type implies: !std::is_trivial_v<T> and Capacity != 0
 template <typename T, std::size_t Capacity>
 struct inplace_vector_bytes_based_storage {
-  alignas(T) inplace_vector_array_type<std::byte, Capacity * sizeof(T)> elems;
+  alignas(T) std::array<std::byte, Capacity * sizeof(T)> elems;
 
-  T *begin() { return std::launder(reinterpret_cast<const T *>(elems)); }
+  T *begin() { return std::launder(reinterpret_cast<const T *>(elems.data())); }
   const T *begin() const {
-    return std::launder(reinterpret_cast<const T *>(elems));
+    return std::launder(reinterpret_cast<const T *>(elems.data()));
   }
 };
 

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cstddef>
 #include <exception>
 #include <iterator>
 #include <limits>
@@ -75,7 +76,7 @@ struct inplace_vector_array_based_storage {
 // Selecting this storage type implies: !std::is_trivial_v<T> and Capacity != 0
 template <typename T, std::size_t Capacity>
 struct inplace_vector_bytes_based_storage {
-  alignas(T) unsigned char elems[Capacity * sizeof(T)];
+  alignas(T) std::byte elems[Capacity * sizeof(T)];
 
   T *begin() { return std::launder(reinterpret_cast<const T *>(elems)); }
   const T *begin() const {

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -85,7 +85,6 @@ template <typename T, std::size_t Capacity>
 struct inplace_vector_destruct_base {
   using size_type = std::size_t;
   using internal_size_type = inplace_vector_internal_size_type<Capacity>;
-
   using internal_storage_type =
       std::conditional_t<std::is_trivial_v<T>,
                          inplace_vector_array_based_storage<T, Capacity>,

--- a/tests/beman/inplace_vector/CMakeLists.txt
+++ b/tests/beman/inplace_vector/CMakeLists.txt
@@ -10,13 +10,17 @@ target_link_libraries(beman.inplace_vector.test PRIVATE beman.inplace_vector)
 
 add_test(NAME beman.inplace_vector.test COMMAND beman.inplace_vector.test)
 
-# constexpr test
-add_executable(beman.inplace_vector.constexpr_test constexpr.test.cpp)
-target_link_libraries(
-    beman.inplace_vector.constexpr_test
-    PRIVATE beman.inplace_vector
-)
-add_test(
-    NAME beman.inplace_vector.constexpr_test
-    COMMAND beman.inplace_vector.constexpr_test
-)
+if(CMAKE_CXX_STANDARD GREATER_EQUAL 20)
+    # constexpr test
+    add_executable(beman.inplace_vector.constexpr_test constexpr.test.cpp)
+    target_link_libraries(
+        beman.inplace_vector.constexpr_test
+        PRIVATE beman.inplace_vector
+    )
+    add_test(
+        NAME beman.inplace_vector.constexpr_test
+        COMMAND beman.inplace_vector.constexpr_test
+    )
+else()
+    message(WARNING "C++20 or later is not enabled, skipping constexpr test.")
+endif()

--- a/tests/beman/inplace_vector/CMakeLists.txt
+++ b/tests/beman/inplace_vector/CMakeLists.txt
@@ -12,5 +12,11 @@ add_test(NAME beman.inplace_vector.test COMMAND beman.inplace_vector.test)
 
 # constexpr test
 add_executable(beman.inplace_vector.constexpr_test constexpr.test.cpp)
-target_link_libraries(beman.inplace_vector.constexpr_test PRIVATE beman.inplace_vector)
-add_test(NAME beman.inplace_vector.constexpr_test COMMAND beman.inplace_vector.constexpr_test)
+target_link_libraries(
+    beman.inplace_vector.constexpr_test
+    PRIVATE beman.inplace_vector
+)
+add_test(
+    NAME beman.inplace_vector.constexpr_test
+    COMMAND beman.inplace_vector.constexpr_test
+)

--- a/tests/beman/inplace_vector/CMakeLists.txt
+++ b/tests/beman/inplace_vector/CMakeLists.txt
@@ -9,3 +9,8 @@ add_executable(beman.inplace_vector.test inplace_vector.test.cpp)
 target_link_libraries(beman.inplace_vector.test PRIVATE beman.inplace_vector)
 
 add_test(NAME beman.inplace_vector.test COMMAND beman.inplace_vector.test)
+
+# constexpr test
+add_executable(beman.inplace_vector.constexpr_test constexpr.test.cpp)
+target_link_libraries(beman.inplace_vector.constexpr_test PRIVATE beman.inplace_vector)
+add_test(NAME beman.inplace_vector.constexpr_test COMMAND beman.inplace_vector.constexpr_test)

--- a/tests/beman/inplace_vector/constexpr.test.cpp
+++ b/tests/beman/inplace_vector/constexpr.test.cpp
@@ -37,7 +37,7 @@ static_assert(std::invoke([]() {
 
                 return true;
               }),
-              "Should be constexpr for all 0 capacity for trivial type");
+              "0 capacity Trivial type");
 
 static_assert(std::invoke([]() {
                 inplace_vector<NonTrivial, 0> vec;
@@ -54,11 +54,12 @@ static_assert(std::invoke([]() {
                 S_ASSERT(vec.rbegin() == vec.rend());
                 S_ASSERT(vec.crbegin() == vec.crend());
 
+                // push_back
                 S_ASSERT(vec.try_push_back({}) == nullptr);
 
                 return true;
               }),
-              "Should be constexpr for all 0 capacity for non-trivial type");
+              "0 capacity Non-trivial type");
 
 static_assert(std::invoke([]() {
                 // sizes
@@ -141,7 +142,7 @@ static_assert(std::invoke([]() {
 
                 return true;
               }),
-              "Single push_back");
+              "Basic mutation");
 
 int main() {
   // compile means pass

--- a/tests/beman/inplace_vector/constexpr.test.cpp
+++ b/tests/beman/inplace_vector/constexpr.test.cpp
@@ -1,0 +1,148 @@
+#include <beman/inplace_vector/inplace_vector.hpp>
+#include <functional>
+#include <type_traits>
+
+using namespace beman::inplace_vector;
+
+#define S_ASSERT(EXP)                                                          \
+  do {                                                                         \
+    if (!(EXP)) {                                                              \
+      return false;                                                            \
+    }                                                                          \
+  } while (0)
+
+struct NonTrivial {
+  int z = 0;
+};
+static_assert(!std::is_trivial_v<NonTrivial>);
+
+static_assert(std::invoke([]() {
+                inplace_vector<int, 0> vec;
+
+                // sizes
+                S_ASSERT(vec.max_size() == 0);
+                S_ASSERT(vec.capacity() == 0);
+                S_ASSERT(vec.size() == 0);
+                S_ASSERT(vec.empty());
+
+                // itr
+                S_ASSERT(vec.begin() == vec.end());
+                S_ASSERT(vec.cbegin() == vec.cend());
+                S_ASSERT(vec.rbegin() == vec.rend());
+                S_ASSERT(vec.crbegin() == vec.crend());
+
+                // push_back
+                S_ASSERT(vec.try_push_back(0) == nullptr);
+                S_ASSERT(vec.try_emplace_back(0) == nullptr);
+
+                return true;
+              }),
+              "Should be constexpr for all 0 capacity for trivial type");
+
+static_assert(std::invoke([]() {
+                inplace_vector<NonTrivial, 0> vec;
+
+                // sizes
+                S_ASSERT(vec.max_size() == 0);
+                S_ASSERT(vec.capacity() == 0);
+                S_ASSERT(vec.size() == 0);
+                S_ASSERT(vec.empty());
+
+                // itr
+                S_ASSERT(vec.begin() == vec.end());
+                S_ASSERT(vec.cbegin() == vec.cend());
+                S_ASSERT(vec.rbegin() == vec.rend());
+                S_ASSERT(vec.crbegin() == vec.crend());
+
+                S_ASSERT(vec.try_push_back({}) == nullptr);
+
+                return true;
+              }),
+              "Should be constexpr for all 0 capacity for non-trivial type");
+
+static_assert(std::invoke([]() {
+                // sizes
+                {
+                  inplace_vector<int, 1> vec;
+                  vec.push_back(1);
+
+                  S_ASSERT(vec.max_size() == 1);
+                  S_ASSERT(vec.capacity() == 1);
+                  S_ASSERT(vec.size() == 1);
+                  S_ASSERT(!vec.empty());
+                }
+
+                // Access
+                {
+
+                  inplace_vector<int, 1> vec;
+                  vec.push_back(1);
+
+                  S_ASSERT(vec[0] == 1);
+                  S_ASSERT(vec.front() == 1);
+                  S_ASSERT(vec.back() == 1);
+                }
+
+                // forward itr
+                {
+                  inplace_vector<int, 1> vec;
+                  vec.push_back(1);
+
+                  auto itr = vec.begin();
+                  S_ASSERT(*itr == 1);
+                  itr += 1;
+                  S_ASSERT(itr == vec.end());
+                }
+
+                // backward itr
+                {
+                  inplace_vector<int, 1> vec;
+                  vec.push_back(1);
+
+                  auto itr = vec.rbegin();
+                  S_ASSERT(*itr == 1);
+                  itr += 1;
+                  S_ASSERT(itr == vec.rend());
+                }
+
+                // try variant
+                {
+                  inplace_vector<int, 1> vec;
+                  S_ASSERT(*vec.try_push_back(1) == 1);
+                  S_ASSERT(vec.try_push_back(2) == nullptr);
+                }
+
+                return true;
+              }),
+              "Single push_back");
+
+static_assert(std::invoke([]() {
+                // push pop back
+                {
+                  inplace_vector<int, 5> vec;
+                  vec.push_back(1);
+                  vec.pop_back();
+
+                  S_ASSERT(vec.empty());
+                }
+
+                // resize
+                {
+                  inplace_vector<int, 5> vec;
+                  vec.push_back(1);
+                  vec.push_back(2);
+
+                  S_ASSERT(vec.size() == 2);
+
+                  vec.resize(1);
+                  S_ASSERT(vec.size() == 1);
+                  S_ASSERT(vec.back() == 1);
+                }
+
+                return true;
+              }),
+              "Single push_back");
+
+int main() {
+  // compile means pass
+}

--- a/tests/beman/inplace_vector/constexpr.test.cpp
+++ b/tests/beman/inplace_vector/constexpr.test.cpp
@@ -16,50 +16,54 @@ struct NonTrivial {
 };
 static_assert(!std::is_trivial_v<NonTrivial>);
 
+template <typename T> constexpr bool test_empty_vec(T &vec) {
+
+  // sizes
+  S_ASSERT(vec.max_size() == 0);
+  S_ASSERT(vec.capacity() == 0);
+  S_ASSERT(vec.size() == 0);
+  S_ASSERT(vec.empty());
+
+  // itr
+  S_ASSERT(vec.begin() == vec.end());
+  S_ASSERT(vec.cbegin() == vec.cend());
+  S_ASSERT(vec.rbegin() == vec.rend());
+  S_ASSERT(vec.crbegin() == vec.crend());
+
+  // push_back
+  S_ASSERT(vec.try_push_back({}) == nullptr);
+  S_ASSERT(vec.try_emplace_back() == nullptr);
+
+  return true;
+}
+
 static_assert(std::invoke([]() {
                 inplace_vector<int, 0> vec;
-
-                // sizes
-                S_ASSERT(vec.max_size() == 0);
-                S_ASSERT(vec.capacity() == 0);
-                S_ASSERT(vec.size() == 0);
-                S_ASSERT(vec.empty());
-
-                // itr
-                S_ASSERT(vec.begin() == vec.end());
-                S_ASSERT(vec.cbegin() == vec.cend());
-                S_ASSERT(vec.rbegin() == vec.rend());
-                S_ASSERT(vec.crbegin() == vec.crend());
-
-                // push_back
-                S_ASSERT(vec.try_push_back(0) == nullptr);
-                S_ASSERT(vec.try_emplace_back(0) == nullptr);
-
+                test_empty_vec(vec);
                 return true;
               }),
               "0 capacity Trivial type");
 
 static_assert(std::invoke([]() {
+                inplace_vector<const int, 0> vec;
+                test_empty_vec(vec);
+                return true;
+              }),
+              "0 capacity Trivial const type");
+
+static_assert(std::invoke([]() {
                 inplace_vector<NonTrivial, 0> vec;
-
-                // sizes
-                S_ASSERT(vec.max_size() == 0);
-                S_ASSERT(vec.capacity() == 0);
-                S_ASSERT(vec.size() == 0);
-                S_ASSERT(vec.empty());
-
-                // itr
-                S_ASSERT(vec.begin() == vec.end());
-                S_ASSERT(vec.cbegin() == vec.cend());
-                S_ASSERT(vec.rbegin() == vec.rend());
-                S_ASSERT(vec.crbegin() == vec.crend());
-
-                // push_back
-                S_ASSERT(vec.try_push_back({}) == nullptr);
-
+                test_empty_vec(vec);
                 return true;
               }),
               "0 capacity Non-trivial type");
+
+static_assert(std::invoke([]() {
+                inplace_vector<const NonTrivial, 0> vec;
+                test_empty_vec(vec);
+                return true;
+              }),
+              "0 capacity Non-trivial const type");
 
 static_assert(std::invoke([]() {
                 // sizes

--- a/tests/beman/inplace_vector/inplace_vector.test.cpp
+++ b/tests/beman/inplace_vector/inplace_vector.test.cpp
@@ -7,7 +7,7 @@ using namespace beman::inplace_vector;
 struct NonTrivial {
   int z = 5;
 
-  bool operator==(NonTrivial const &other) { return this->z == other.z; }
+  bool operator==(NonTrivial const &other) const { return this->z == other.z; }
 };
 static_assert(!std::is_trivial_v<NonTrivial>);
 

--- a/tests/beman/inplace_vector/inplace_vector.test.cpp
+++ b/tests/beman/inplace_vector/inplace_vector.test.cpp
@@ -1,7 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <beman/inplace_vector/inplace_vector.hpp>
+#include <type_traits>
 
 using namespace beman::inplace_vector;
+
+struct NonTrivial {
+  int z = 5;
+
+  bool operator==(NonTrivial const &other) { return this->z == other.z; }
+};
+static_assert(!std::is_trivial_v<NonTrivial>);
 
 template <typename T> constexpr void test() {
   using vec = inplace_vector<T, 42>;
@@ -82,8 +90,19 @@ void test_exceptions() {
     }
   }
 }
+
+template <typename T> void test_const() {
+  inplace_vector<const T, 20> vec;
+  vec.push_back({50});
+  const T &first = vec.front();
+  assert(first == T{50});
+}
+
 int main() {
   test<int>();
   test_exceptions();
+
+  test_const<int>();
+  test_const<NonTrivial>();
   return 0;
 }


### PR DESCRIPTION
Make `inplace_vector` `constexpr` friendly by providing an T-based array storage alternative that avoids the needs of `reinterpret_cast`.

This storage alternative is only selected when `std::is_trivial(T)`, as that's the requirement for enabling constexpr in the paper.

Adds constexpr based tests.

Related sections in paper:

> constexpr support
>> Note: this revision brings back this section which was dropped in R8 because per LEWG discussion, LEWG thought that this whole type was implementable within constexpr for all types. The design intent of LEWG was to make it "as constexpr as possible."

> The API of inplace_vector<T, Capacity> can be used in constexpr-contexts if is_trivially_copyable_v<T>, is_default_constructible_v<T>, and is_trivially_destructible<T> are true. This proposal only supports using the constexpr methods in constant expressions if is_trivial_t<T> is true.
> The implementation cost of this is small. The prototye implementation specializes the storage to use a C array with value-initialized elements.
> This negatively impacts the algorithmic complexity of inplace_vector constructors for these types from O(size) to O(capacity). When value-initialization takes place at run-time, this difference is significant.
> Vectors with large capacity requirements are better served by vector instead.

All member functions should be constexpr. 

Added a constexpr test that is not finished, I fear the code-fix resulted due to passing constexpr on all functions would result in too big of a PR. Currently `[container.reqmts]` related requirement is tested and fixed for int type.

Closes #17