### PR TITLE
Feature/add gcov target

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Build Release
         run: |
           cmake --build build --config Release --verbose
-          # TODO: cmake --build build --config Release --target all_verify_interface_header_sets
+          cmake --build build --config Release --target all_verify_interface_header_sets
           cmake --install build --config Release --prefix /tmp/beman.inplace_vector
           find /tmp/beman.inplace_vector -type f
       - name: Test Release
@@ -112,7 +112,7 @@ jobs:
       - name: Build Debug
         run: |
           cmake --build build --config Debug --verbose
-          # TODO: cmake --build build --config Debug --target all_verify_interface_header_sets
+          cmake --build build --config Debug --target all_verify_interface_header_sets
           cmake --install build --config Debug --prefix /tmp/beman.inplace_vector
           find /tmp/beman.inplace_vector -type f
       - name: Test Debug

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build
 /out
 CMakeUserPresets.json
+CMakeCache.txt
+CMakeFiles/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ option(
 
 set(CPACK_GENERATOR TGZ)
 
-# includes
 include(GNUInstallDirs)
 include(CPack)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,3 +76,15 @@ endif()
 if(BEMAN_EXEMPLAR_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
+
+# Coverage
+configure_file(cmake/gcovr.cfg.in gcovr.cfg @ONLY)
+
+add_custom_target(
+    process_coverage
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    DEPENDS test
+    COMMENT "Running gcovr to process coverage results"
+    COMMAND mkdir -p coverage
+    COMMAND gcovr --config gcovr.cfg .
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,12 +55,7 @@ set_target_properties(
     beman.inplace_vector
     PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON
 )
-target_compile_features(
-    beman.inplace_vector
-    INTERFACE
-        "$<$<COMPILE_FEATURES:cxx_std_23>:cxx_std_23>"
-        "$<$<NOT:$<COMPILE_FEATURES:cxx_std_23>>:cxx_std_20>"
-)
+target_compile_features(beman.inplace_vector INTERFACE cxx_std_23)
 
 set(TARGET_PACKAGE_NAME ${PROJECT_NAME}-config)
 set(TARGETS_EXPORT_NAME ${PROJECT_NAME}-targets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # cmake-format: on
 
-cmake_minimum_required(VERSION 3.23)
+set(CMAKE_SKIP_TEST_ALL_DEPENDENCY FALSE)
+
+cmake_minimum_required(VERSION 3.25...3.31)
 
 project(
     beman.inplace_vector
@@ -12,6 +14,10 @@ project(
         "A dynamically-resizable vector with fixed capacity and embedded storage"
     LANGUAGES CXX
 )
+
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+    message(FATAL_ERROR "In-source builds are not allowed!")
+endif()
 
 # [CMAKE.SKIP_EXAMPLES]
 option(
@@ -27,38 +33,49 @@ option(
     ${PROJECT_IS_TOP_LEVEL}
 )
 
+set(CPACK_GENERATOR TGZ)
+
+# includes
 include(GNUInstallDirs)
+include(CPack)
 
 add_library(beman.inplace_vector INTERFACE)
 # [CMAKE.LIBRARY_ALIAS]
 add_library(beman::inplace_vector ALIAS beman.inplace_vector)
 
-target_include_directories(
+target_sources(
+    beman.inplace_vector
+    PUBLIC
+        FILE_SET inplace_vector_public_headers
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+        FILES
+            "${CMAKE_CURRENT_SOURCE_DIR}/include/beman/inplace_vector/inplace_vector.hpp"
+)
+set_target_properties(
+    beman.inplace_vector
+    PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON
+)
+target_compile_features(
     beman.inplace_vector
     INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>
+        "$<$<COMPILE_FEATURES:cxx_std_23>:cxx_std_23>"
+        "$<$<NOT:$<COMPILE_FEATURES:cxx_std_23>>:cxx_std_20>"
 )
+
+set(TARGET_PACKAGE_NAME ${PROJECT_NAME}-config)
+set(TARGETS_EXPORT_NAME ${PROJECT_NAME}-targets)
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
 # Install the InplaceVector library to the appropriate destination
 install(
     TARGETS beman.inplace_vector
     EXPORT ${TARGETS_EXPORT_NAME}
-    DESTINATION
-    ${CMAKE_INSTALL_LIBDIR}
-)
-
-# Install the header files to the appropriate destination
-install(
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_PROJECT_NAME}
-    FILES_MATCHING
-    PATTERN
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/beman/inplace_vector/inplace_vector.hpp"
+    FILE_SET inplace_vector_public_headers
 )
 
 if(BEMAN_INPLACE_VECTOR_BUILD_TESTS)
-    include(CTest)
+    enable_testing()
     add_subdirectory(tests/beman/inplace_vector)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ TODO: tested platforms.
 
 ```text
 # Configure build
-$ cmake -S . -B build -DCMAKE_CXX_STANDARD=20
+$ cmake -S . -B build -DCMAKE_CXX_STANDARD=23
 -- The CXX compiler identification is GNU 11.4.0
 -- Detecting CXX compiler ABI info
 -- Detecting CXX compiler ABI info - done

--- a/cmake/gcovr.cfg.in
+++ b/cmake/gcovr.cfg.in
@@ -4,7 +4,6 @@ root = @CMAKE_SOURCE_DIR@
 cobertura = @CMAKE_BINARY_DIR@/coverage/cobertura.xml
 sonarqube = @CMAKE_BINARY_DIR@/coverage/sonarqube.xml
 html-details = @CMAKE_BINARY_DIR@/coverage/coverage.html
-# XXX gcov-executable = @GCOV_EXECUTABLE@
 gcov-parallel = yes
 html-theme = blue
 html-self-contained = yes

--- a/cmake/gcovr.cfg.in
+++ b/cmake/gcovr.cfg.in
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception.
+
 root = @CMAKE_SOURCE_DIR@
 cobertura = @CMAKE_BINARY_DIR@/coverage/cobertura.xml
 sonarqube = @CMAKE_BINARY_DIR@/coverage/sonarqube.xml

--- a/cmake/gcovr.cfg.in
+++ b/cmake/gcovr.cfg.in
@@ -1,0 +1,11 @@
+root = @CMAKE_SOURCE_DIR@
+cobertura = @CMAKE_BINARY_DIR@/coverage/cobertura.xml
+sonarqube = @CMAKE_BINARY_DIR@/coverage/sonarqube.xml
+html-details = @CMAKE_BINARY_DIR@/coverage/coverage.html
+# XXX gcov-executable = @GCOV_EXECUTABLE@
+gcov-parallel = yes
+html-theme = blue
+html-self-contained = yes
+print-summary = yes
+filter = .*/beman/inplace_vector/.*
+exclude = .*\.t\.cpp


### PR DESCRIPTION
Adds test coverage report feature. 
Can be invoked with `cmake process_coverage`, the coverage report is generated in `build/coverage/coverage.html`.
Needs client to install `gcovr`.

**NOTE**: This is **second** of a series of PR based on https://github.com/bemanproject/inplace_vector/pull/14

- [ ] **Depends** on https://github.com/bemanproject/inplace_vector/pull/33

see too https://github.com/bemanproject/optional26/pull/82