### PR TITLE
specify namespace std

### DIFF
--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -464,9 +464,9 @@ public:
   constexpr __non_trivial &operator=(__non_trivial &&) noexcept = default;
 
   constexpr ~__non_trivial()
-    requires(is_trivially_destructible_v<__T>)
+    requires(std::is_trivially_destructible_v<__T>)
   = default;
-  constexpr ~__non_trivial() { destroy(__data(), __data() + __size()); }
+  constexpr ~__non_trivial() { std::destroy(__data(), __data() + __size()); }
 };
 
 // Selects the vector storage.
@@ -701,7 +701,7 @@ public:
   }
 
   template <class... __Args>
-  constexpr T &emplace_back(__Args &&...__args)
+  constexpr __T &emplace_back(__Args &&...__args)
     requires(std::constructible_from<__T, __Args...>)
   {
     if (!try_emplace_back(std::forward<__Args>(__args)...)) [[unlikely]]
@@ -954,7 +954,7 @@ public:
 
   constexpr inplace_vector(const inplace_vector &__x)
     requires(__N != 0 && !std::is_trivially_copy_constructible_v<__T> &&
-             copyable<__T>)
+             std::copyable<__T>)
   {
     for (auto &&__e : __x)
       emplace_back(__e);

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -495,7 +495,7 @@ public:
   using reference = value_type &;
   using const_reference = const value_type &;
   using size_type = size_t;
-  using difference_type = ptrdiff_t;
+  using difference_type = std::ptrdiff_t;
   using iterator = pointer;
   using const_iterator = const_pointer;
   using reverse_iterator = std::reverse_iterator<iterator>;

--- a/tests/beman/inplace_vector/container_requirements.test.cpp
+++ b/tests/beman/inplace_vector/container_requirements.test.cpp
@@ -998,7 +998,7 @@ TYPED_TEST(SequenceContainerRequirements, ElementAccess) {
 
   auto device = this->unique();
 
-  for (auto i = 0uz; i < device.size(); ++i)
+  for (auto i = 0ul; i < device.size(); ++i)
     EXPECT_EQ(device[i], *(device.begin() + i));
 }
 


### PR DESCRIPTION
This removes use of `using namespace std`.

Waiting for #55 so we can make sure we don't break anything.