### PR TITLE
Add build option to turn off dynamic size type selection

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -120,6 +120,51 @@ jobs:
       - name: Test Debug
         run: ctest --test-dir build --build-config Debug
 
+  configuration-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        args:
+          - name: "Disable build testing"
+            arg: "-DBEMAN_INPLACE_VECTOR_BUILD_TESTS=OFF"
+          - name: "Disable example building"
+            arg: "-DBEMAN_INPLACE_VECTOR_BUILD_EXAMPLES=OFF"
+          - name: "Enable fixed size type"
+            arg: "-DBEMAN_INPLACE_VECTOR_FIXED_SIZE_T=ON"
+    name: "CMake: ${{ matrix.args.name }}"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup build environment
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.25.0"
+          ninjaVersion: "^1.11.1"
+      - name: Print installed software
+        run: |
+          cmake --version
+          ninja --version
+      - name: Configure CMake
+        run: |
+          cmake -B build -S . -DCMAKE_CXX_STANDARD=20 ${{ matrix.args.arg }}
+        env:
+          CMAKE_GENERATOR: "Ninja Multi-Config"
+      - name: Build Release
+        run: |
+          # Portable commands only
+          cmake --build build --config Release --parallel --verbose
+          # cmake --build build --config Release --target all_verify_interface_header_sets
+          cmake --install build --config Release --prefix /opt/beman.inplace_vector
+          ls -R /opt/beman.inplace_vector
+      - name: Build Debug
+        run: |
+          # Portable commands only
+          cmake --build build --config Debug --parallel --verbose
+          # cmake --build build --config Debug --target all_verify_interface_header_sets
+          cmake --install build --config Debug --prefix /opt/beman.inplace_vector
+          ls -R /opt/beman.inplace_vector
+
+
   create-issue-when-fault:
     runs-on: ubuntu-latest
     needs: [test]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ project(
 
 # [CMAKE.SKIP_EXAMPLES]
 option(
-    BEMAN_EXEMPLAR_BUILD_EXAMPLES
+    BEMAN_INPLACE_VECTOR_BUILD_EXAMPLES
     "Enable building examples. Default: ON. Values: { ON, OFF }."
     ${PROJECT_IS_TOP_LEVEL}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,19 @@ option(
     ${PROJECT_IS_TOP_LEVEL}
 )
 
+option(
+    BEMAN_INPLACE_VECTOR_FIXED_SIZE_T
+    "Fixes size_t in inplace_vector, otherwise size_t is dynamic against \
+    inplace_vector's capacity. Default: OFF. Values: { ON, OFF }."
+    OFF
+)
+
+configure_file(
+    "${PROJECT_SOURCE_DIR}/include/beman/inplace_vector/config.hpp.in"
+    "${PROJECT_BINARY_DIR}/include/beman/inplace_vector/config.hpp"
+    @ONLY
+)
+
 include(FetchContent)
 include(GNUInstallDirs)
 
@@ -38,6 +51,7 @@ target_include_directories(
     beman.inplace_vector
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,24 @@ Test project /.../inplace_vector/build
 Total Test time (real) =   0.01 sec
 ```
 
+## Build arguments
+
+### Disable dynamic size type in control block
+
+By default,
+the type of the size variable in the control block is selected to the smallest
+it could be
+(as an upper bound can be established given we know the capacity of the vector).
+
+You can turn off this behavior by setting `BEMAN_INPLACE_VECTOR_FIXED_SIZE_T`
+to `ON`, which fixes the type to `std::size_t`.
+
+Example: configuring the project with fixed size type.
+
+```bash
+cmake -S . -B build -DCMAKE_CXX_STANDARD=20 -DBEMAN_INPLACE_VECTOR_FIXED_SIZE_T=ON
+```
+
 ## Development
 
 ### Linting

--- a/include/beman/inplace_vector/config.hpp.in
+++ b/include/beman/inplace_vector/config.hpp.in
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#define BEMAN_INPLACE_VECTOR_CONFIG
+
+#cmakedefine01 BEMAN_INPLACE_VECTOR_FIXED_SIZE_T

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -472,7 +472,7 @@ public:
   using const_pointer = const T *;
   using reference = value_type &;
   using const_reference = const value_type &;
-  // Note: This may be different from base_t::size_t.
+  // Note: This may be different from base_t::size_type
   using size_type = std::size_t;
   using difference_type = std::ptrdiff_t;
   using iterator = pointer;

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -297,10 +297,10 @@ using smallest_size_t
 // clang-format on
 
 /*
- * This is generally for managing the size type in the storage block.
+ * This is for managing the type of size in the control block.
+ *
  * This behavior can be turned off by setting the
- * BEMAN_INPLACE_VECTOR_FIXED_SIZE_T build option as there has been report of
- * performance impact.
+ * BEMAN_INPLACE_VECTOR_FIXED_SIZE_T build option.
  *
  * This macro is set in the config.hpp.
  */


### PR DESCRIPTION
This is added because there maybe a performance penalty due to dynamic size storage that we will need to investigate, see #53 .

Todo:
- [x] Documentation 
- [x] CI Test