### PR TITLE
Allow using library without cmake generated files

### DIFF
--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -23,6 +23,11 @@
 #define IV_EXPECT(EXPR)
 
 #ifndef BEMAN_IV_THROW_OR_ABORT
+
+#ifndef BEMAN_INPLACE_VECTOR_NO_EXCEPTIONS
+#define BEMAN_INPLACE_VECTOR_NO_EXCEPTIONS() 0
+#endif
+
 #if BEMAN_INPLACE_VECTOR_NO_EXCEPTIONS()
 #include <cstdlib> // for abort
 #define BEMAN_IV_THROW_OR_ABORT(x) abort()


### PR DESCRIPTION
Improve user experience and usability of the library by removing library dependency on cmake generated config file.

This PR is just a suggestion, but I dont think that enforcing cmake generated files on a interface only library is a good think, especially for something as small as inplace vector.