### PR TITLE
move implementation into beman::inplace_vector namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Contributions are welcome.
 
 #include <beman/inplace_vector/inplace_vector.hpp>
 
-using namespace beman;
+using namespace beman::inplace_vector;
 
 /**
  * Generates fibonacci sequence using inplace_vector.
@@ -93,21 +93,21 @@ Note this is not part of the standard Library and should not be relied on once
 `constexpr` requirement stabilize.
 
 Example Usage:
-`static_assert(beman::has_constexpr_support<beman::inplace_vector<int, 5>>)`.
+`static_assert(beman::has_constexpr_support<beman::inplace_vector::inplace_vector<int, 5>>)`.
 
 ### Freestanding
 
-`beman::freestanding::inplace_vector` implements a minimal freestanding version of the specification,
+`beman::inplace_vector::freestanding::inplace_vector` implements a minimal freestanding version of the specification,
 which marks all potentially throwing functions as `= deleted`.
 This is useful for platforms without exception support, as it will generate a compile-time error
 instead of a potential runtime error when trying to use a throwing function.
 
 ``` C++
-beman::inplace_vector<int, 1> iv;
+beman::inplace_vector::inplace_vector<int, 1> iv;
 iv.resize(0); // OK
 iv.resize(10); // will throw or abort
 
-beman::freestanding::inplace_vector<int, 1> fs_iv;
+beman::inplace_vector::freestanding::inplace_vector<int, 1> fs_iv;
 fs_iv.resize(0); // will generate a compile-time error
 fs_iv.resize(10); // will generate a compile-time error
 ```

--- a/examples/fibonacci.cpp
+++ b/examples/fibonacci.cpp
@@ -4,7 +4,7 @@
 
 #include <beman/inplace_vector/inplace_vector.hpp>
 
-using namespace beman;
+using namespace beman::inplace_vector;
 
 /**
  * Generates fibonacci sequence using inplace_vector.

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -44,7 +44,7 @@ inline constexpr from_range_t from_range;
 }; // namespace beman
 
 // Private utilities
-namespace beman::details::inplace_vector {
+namespace beman::inplace_vector::details {
 
 // clang-format off
 // Smallest unsigned integer that can represent values in [0, N].
@@ -80,10 +80,7 @@ concept lessthan_comparable = requires(const T &a, const T &b) {
   { a < b } -> std::convertible_to<bool>;
 };
 
-} // namespace beman::details::inplace_vector
-
 // Types implementing the `inplace_vector`'s storage
-namespace beman::details::inplace_vector {
 namespace storage {
 
 // Storage for zero elements.
@@ -271,22 +268,20 @@ public:
   // element access
 
   constexpr reference operator[](size_type n) {
-    return details::inplace_vector::index(*this, n);
+    return details::index(*this, n);
   }
   constexpr const_reference operator[](size_type n) const {
-    return details::inplace_vector::index(*this, n);
+    return details::index(*this, n);
   }
-  constexpr reference front() {
-    return details::inplace_vector::index(*this, size_type(0));
-  }
+  constexpr reference front() { return details::index(*this, size_type(0)); }
   constexpr const_reference front() const {
-    return details::inplace_vector::index(*this, size_type(0));
+    return details::index(*this, size_type(0));
   }
   constexpr reference back() {
-    return details::inplace_vector::index(*this, size() - size_type(1));
+    return details::index(*this, size() - size_type(1));
   }
   constexpr const_reference back() const {
-    return details::inplace_vector::index(*this, size() - size_type(1));
+    return details::index(*this, size() - size_type(1));
   }
 
   // [containers.sequences.inplace_vector.data], data access
@@ -361,7 +356,7 @@ public:
     return unchecked_emplace_back(std::forward<T &&>(x));
   }
 
-  template <details::inplace_vector::container_compatible_range<T> R>
+  template <details::container_compatible_range<T> R>
   constexpr std::ranges::borrowed_iterator_t<R> try_append_range(R &&rg)
     requires(std::constructible_from<T, std::ranges::range_reference_t<R>>)
   {
@@ -428,7 +423,7 @@ public:
 
   constexpr friend auto operator<=>(const inplace_vector_base &x,
                                     const inplace_vector_base &y)
-    requires(beman::details::inplace_vector::lessthan_comparable<T>)
+    requires(details::lessthan_comparable<T>)
   {
     if constexpr (std::three_way_comparable<T>) {
       return std::lexicographical_compare_three_way(x.begin(), x.end(),
@@ -514,19 +509,17 @@ public:
   }
 };
 
-} // namespace beman::details::inplace_vector
+} // namespace beman::inplace_vector::details
 
-namespace beman {
+namespace beman::inplace_vector {
 
 template <typename IV>
 concept has_constexpr_support =
-    details::inplace_vector::satify_constexpr<typename IV::value_type,
-                                              IV::capacity()>;
+    details::satify_constexpr<typename IV::value_type, IV::capacity()>;
 
 /// Dynamically-resizable fixed-N vector with inplace storage.
 template <class T, size_t N>
-struct inplace_vector
-    : public details::inplace_vector::inplace_vector_base<T, N> {
+struct inplace_vector : public details::inplace_vector_base<T, N> {
   using value_type = T;
   using pointer = T *;
   using const_pointer = const T *;
@@ -563,7 +556,7 @@ struct inplace_vector
     return this->back();
   }
 
-  template <details::inplace_vector::container_compatible_range<T> R>
+  template <details::container_compatible_range<T> R>
   constexpr void append_range(R &&rg)
     requires(std::constructible_from<T, std::ranges::range_reference_t<R>>)
   {
@@ -614,7 +607,7 @@ struct inplace_vector
     return pos;
   }
 
-  template <details::inplace_vector::container_compatible_range<T> R>
+  template <details::container_compatible_range<T> R>
   constexpr iterator insert_range(const_iterator position, R &&rg)
     requires(std::constructible_from<T, std::ranges::range_reference_t<R>> &&
              std::movable<T>)
@@ -672,7 +665,7 @@ struct inplace_vector
     this->clear();
     insert(this->begin(), first, last);
   }
-  template <details::inplace_vector::container_compatible_range<T> R>
+  template <details::container_compatible_range<T> R>
   constexpr void assign_range(R &&rg)
     requires(std::constructible_from<T, std::ranges::range_reference_t<R>> &&
              std::movable<T>)
@@ -738,13 +731,13 @@ struct inplace_vector
     if (pos >= this->size()) [[unlikely]] {
       BEMAN_IV_THROW_OR_ABORT(std::out_of_range("inplace_vector::at"));
     }
-    return details::inplace_vector::index(*this, pos);
+    return details::index(*this, pos);
   }
   constexpr const_reference at(size_type pos) const {
     if (pos >= this->size()) [[unlikely]] {
       BEMAN_IV_THROW_OR_ABORT(std::out_of_range("inplace_vector::at"));
     }
-    return details::inplace_vector::index(*this, pos);
+    return details::index(*this, pos);
   }
 
   // [containers.sequences.inplace_vector.cons], construct/copy/destroy
@@ -780,7 +773,7 @@ struct inplace_vector
     insert(this->begin(), first, last);
   }
 
-  template <details::inplace_vector::container_compatible_range<T> R>
+  template <details::container_compatible_range<T> R>
   constexpr inplace_vector(beman::from_range_t, R &&rg)
     requires(std::constructible_from<T, std::ranges::range_reference_t<R>> &&
              std::movable<T>)
@@ -791,8 +784,7 @@ struct inplace_vector
 
 namespace freestanding {
 template <class T, size_t N>
-struct inplace_vector
-    : public details::inplace_vector::inplace_vector_base<T, N> {
+struct inplace_vector : public details::inplace_vector_base<T, N> {
   using value_type = T;
   using pointer = T *;
   using const_pointer = const T *;
@@ -818,7 +810,7 @@ struct inplace_vector
     requires(std::constructible_from<T, T &&>)
   = delete;
 
-  template <details::inplace_vector::container_compatible_range<T> R>
+  template <details::container_compatible_range<T> R>
   constexpr void append_range(R &&rg)
     requires(std::constructible_from<T, std::ranges::range_reference_t<R>>)
   = delete;
@@ -835,7 +827,7 @@ struct inplace_vector
              std::movable<T>)
   = delete;
 
-  template <details::inplace_vector::container_compatible_range<T> R>
+  template <details::container_compatible_range<T> R>
   constexpr iterator insert_range(const_iterator position, R &&rg)
     requires(std::constructible_from<T, std::ranges::range_reference_t<R>> &&
              std::movable<T>)
@@ -871,7 +863,7 @@ struct inplace_vector
     requires(std::constructible_from<T, std::iter_reference_t<InputIterator>> &&
              std::movable<T>)
   = delete;
-  template <details::inplace_vector::container_compatible_range<T> R>
+  template <details::container_compatible_range<T> R>
   constexpr void assign_range(R &&rg)
     requires(std::constructible_from<T, std::ranges::range_reference_t<R>> &&
              std::movable<T>)
@@ -925,7 +917,7 @@ struct inplace_vector
              std::movable<T>)
   = delete;
 
-  template <details::inplace_vector::container_compatible_range<T> R>
+  template <details::container_compatible_range<T> R>
   constexpr inplace_vector(beman::from_range_t, R &&rg)
     requires(std::constructible_from<T, std::ranges::range_reference_t<R>> &&
              std::movable<T>)
@@ -935,8 +927,8 @@ struct inplace_vector
 } // namespace freestanding
 
 template <typename T, std::size_t N, typename U = T>
-constexpr std::size_t
-erase(details::inplace_vector::inplace_vector_base<T, N> &c, const U &value) {
+constexpr std::size_t erase(details::inplace_vector_base<T, N> &c,
+                            const U &value) {
   auto it = std::remove(c.begin(), c.end(), value);
   auto r = std::distance(it, c.end());
   c.erase(it, c.end());
@@ -944,16 +936,15 @@ erase(details::inplace_vector::inplace_vector_base<T, N> &c, const U &value) {
 }
 
 template <typename T, std::size_t N, typename Predicate>
-constexpr std::size_t
-erase_if(details::inplace_vector::inplace_vector_base<T, N> &c,
-         Predicate pred) {
+constexpr std::size_t erase_if(details::inplace_vector_base<T, N> &c,
+                               Predicate pred) {
   auto it = std::remove_if(c.begin(), c.end(), pred);
   auto r = std::distance(it, c.end());
   c.erase(it, c.end());
   return r;
 }
 
-} // namespace beman
+} // namespace beman::inplace_vector
 
 #undef IV_EXPECT
 

--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -37,14 +37,11 @@
 #endif
 #endif
 
-// beman::from_range_t
-namespace beman {
-struct from_range_t {};
-inline constexpr from_range_t from_range;
-}; // namespace beman
-
 // Private utilities
 namespace beman::inplace_vector::details {
+
+struct from_range_t {};
+inline constexpr from_range_t from_range;
 
 // clang-format off
 // Smallest unsigned integer that can represent values in [0, N].
@@ -774,7 +771,7 @@ struct inplace_vector : public details::inplace_vector_base<T, N> {
   }
 
   template <details::container_compatible_range<T> R>
-  constexpr inplace_vector(beman::from_range_t, R &&rg)
+  constexpr inplace_vector(details::from_range_t, R &&rg)
     requires(std::constructible_from<T, std::ranges::range_reference_t<R>> &&
              std::movable<T>)
   {
@@ -918,7 +915,7 @@ struct inplace_vector : public details::inplace_vector_base<T, N> {
   = delete;
 
   template <details::container_compatible_range<T> R>
-  constexpr inplace_vector(beman::from_range_t, R &&rg)
+  constexpr inplace_vector(beman::inplace_vector::details::from_range_t, R &&rg)
     requires(std::constructible_from<T, std::ranges::range_reference_t<R>> &&
              std::movable<T>)
   = delete;

--- a/tests/beman/inplace_vector/compare.test.cpp
+++ b/tests/beman/inplace_vector/compare.test.cpp
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <compare>
 
-using namespace beman;
+using namespace beman::inplace_vector;
 
 template <class T>
 concept has_threeway = requires(const T &t) {
@@ -13,7 +13,7 @@ concept has_threeway = requires(const T &t) {
 
 template <class T>
 concept lessthan_comparable =
-    beman::details::inplace_vector::lessthan_comparable<T>;
+    beman::inplace_vector::details::lessthan_comparable<T>;
 
 template <typename T> struct vec_list {
   T empty;

--- a/tests/beman/inplace_vector/constexpr.test.cpp
+++ b/tests/beman/inplace_vector/constexpr.test.cpp
@@ -31,8 +31,8 @@ struct Some {
 };
 static_assert(std::is_trivial_v<Some>);
 
-using beman::has_constexpr_support;
-using beman::inplace_vector;
+using beman::inplace_vector::has_constexpr_support;
+using beman::inplace_vector::inplace_vector;
 
 static_assert(has_constexpr_support<inplace_vector<int, 50>>);
 static_assert(has_constexpr_support<inplace_vector<Some, 50>>);
@@ -45,8 +45,8 @@ static_assert(!has_constexpr_support<inplace_vector<std::unique_ptr<int>, 50>>);
 
 #define TEST(NAME)                                                             \
   static_assert(std::invoke([]() {                                             \
-                  NAME<beman::inplace_vector<int, 20>>();                      \
-                  NAME<beman::inplace_vector<Some, 20>>();                     \
+                  NAME<beman::inplace_vector::inplace_vector<int, 20>>();      \
+                  NAME<beman::inplace_vector::inplace_vector<Some, 20>>();     \
                   return true;                                                 \
                 }),                                                            \
                 "##NAME");
@@ -269,8 +269,8 @@ TEST(test_op_comp);
 
 template <typename IV> constexpr void test_erase() {
   IV v{0, 1, 2, 3, 3, 5};
-  (void)beman::erase(v, 3);
-  (void)beman::erase_if(v, [](auto v) { return v < 3; });
+  (void)beman::inplace_vector::erase(v, 3);
+  (void)beman::inplace_vector::erase_if(v, [](auto v) { return v < 3; });
 }
 TEST(test_erase)
 
@@ -298,7 +298,7 @@ static_assert(!has_constexpr_support<inplace_vector<Complex, 50>>);
 
 template <typename T> constexpr void speical_test_empty() {
   static_assert(!std::is_trivially_default_constructible_v<T>);
-  using IV = beman::inplace_vector<T, 0>;
+  using IV = beman::inplace_vector::inplace_vector<T, 0>;
 
   std::array<T, 10> arr;
   arr.fill(T{50});

--- a/tests/beman/inplace_vector/constexpr.test.cpp
+++ b/tests/beman/inplace_vector/constexpr.test.cpp
@@ -70,7 +70,7 @@ template <typename IV> constexpr void test_constructors() {
     IV v(arr.begin(), arr.end());
   }
   {
-    IV v(beman::from_range_t{}, arr);
+    IV v(beman::inplace_vector::details::from_range_t{}, arr);
   }
   {
     IV other{0, 1};

--- a/tests/beman/inplace_vector/constructors.test.cpp
+++ b/tests/beman/inplace_vector/constructors.test.cpp
@@ -115,7 +115,7 @@ TYPED_TEST(Constructors, CopyRanges) {
   auto reference = this->unique();
 
   {
-    IV device(beman::from_range, reference);
+    IV device(beman::inplace_vector::details::from_range, reference);
     EXPECT_EQ(device, reference);
   }
 
@@ -123,13 +123,15 @@ TYPED_TEST(Constructors, CopyRanges) {
     return;
 
   {
-    IV device(beman::from_range, reference | std::ranges::views::take(1));
+    IV device(beman::inplace_vector::details::from_range,
+              reference | std::ranges::views::take(1));
     EXPECT_EQ(device, IV{reference.front()});
   }
 
   {
     auto mid = std::midpoint(0ul, reference.size());
-    IV device(beman::from_range, reference | std::ranges::views::take(mid));
+    IV device(beman::inplace_vector::details::from_range,
+              reference | std::ranges::views::take(mid));
     EXPECT_EQ(device, IV(reference.begin(), reference.begin() + mid));
   }
 }

--- a/tests/beman/inplace_vector/constructors.test.cpp
+++ b/tests/beman/inplace_vector/constructors.test.cpp
@@ -137,8 +137,8 @@ TYPED_TEST(Constructors, CopyRanges) {
 TYPED_TEST(Constructors, freestandingConversion) {
   using T = TestFixture::T;
 
-  using IV = beman::inplace_vector<T, 5>;
-  using FS = beman::freestanding::inplace_vector<T, 5>;
+  using IV = beman::inplace_vector::inplace_vector<T, 5>;
+  using FS = beman::inplace_vector::freestanding::inplace_vector<T, 5>;
 
   static_assert(std::is_constructible_v<FS, FS>);
   static_assert(std::is_constructible_v<IV, IV>);

--- a/tests/beman/inplace_vector/erasure.test.cpp
+++ b/tests/beman/inplace_vector/erasure.test.cpp
@@ -35,7 +35,7 @@ TYPED_TEST(Erasure, ByValue) {
       device.push_back(duplicates);
   }
 
-  beman::erase(device, duplicates);
+  beman::inplace_vector::erase(device, duplicates);
   EXPECT_EQ(uniques, device);
 }
 
@@ -59,8 +59,8 @@ TYPED_TEST(Erasure, ByPred) {
   for (auto i = 0; i < static_cast<int>(device.capacity()); ++i)
     device.push_back(T{i});
 
-  beman::erase_if(device,
-                  [&](auto &v) { return v.value > (device.capacity() / 2); });
+  beman::inplace_vector::erase_if(
+      device, [&](auto &v) { return v.value > (device.capacity() / 2); });
   EXPECT_TRUE(std::all_of(device.begin(), device.end(), [&](auto val) {
     return val.value <= (device.capacity() / 2);
   }));

--- a/tests/beman/inplace_vector/freestanding.test.cpp
+++ b/tests/beman/inplace_vector/freestanding.test.cpp
@@ -160,8 +160,11 @@ TEST(Freestanding, deleted) {
   static_assert(!std::is_constructible_v<FIV, input_iterator, input_iterator>);
 
   // constexpr inplace_vector(from_range_t, R&& rg);
-  static_assert(std::is_constructible_v<IV, beman::from_range_t, range>);
-  static_assert(!std::is_constructible_v<FIV, beman::from_range_t, range>);
+  static_assert(
+      std::is_constructible_v<IV, beman::inplace_vector::details::from_range_t,
+                              range>);
+  static_assert(!std::is_constructible_v<
+                FIV, beman::inplace_vector::details::from_range_t, range>);
 
   // constexpr inplace_vector(initializer_list<T> il);
   static_assert(std::is_constructible_v<IV, initializer_list>);

--- a/tests/beman/inplace_vector/freestanding.test.cpp
+++ b/tests/beman/inplace_vector/freestanding.test.cpp
@@ -137,8 +137,8 @@ concept has_insert_initializer =
 
 TEST(Freestanding, deleted) {
 
-  using IV = beman::inplace_vector<int, 10>;
-  using FIV = beman::freestanding::inplace_vector<int, 10>;
+  using IV = beman::inplace_vector::inplace_vector<int, 10>;
+  using FIV = beman::inplace_vector::freestanding::inplace_vector<int, 10>;
 
   using range = std::array<int, 10>;
   using input_iterator = std::istream_iterator<int>;
@@ -256,7 +256,7 @@ TEST(Freestanding, deleted) {
 }
 
 TEST(Freestanding, usage) {
-  using IV = beman::freestanding::inplace_vector<int, 10>;
+  using IV = beman::inplace_vector::freestanding::inplace_vector<int, 10>;
   using T = IV::value_type;
 
   IV device;

--- a/tests/beman/inplace_vector/gtest_setup.hpp
+++ b/tests/beman/inplace_vector/gtest_setup.hpp
@@ -348,7 +348,7 @@ template <typename Param> class IVBasicTest : public ::testing::Test {
 public:
   using T = Param::value_type;
   inline static constexpr std::size_t N = Param::capacity;
-  using X = beman::inplace_vector<T, N>;
+  using X = beman::inplace_vector::inplace_vector<T, N>;
   using IV = X;
 
   // Returns IV of size n with unique values

--- a/tests/beman/inplace_vector/inplace_vector.test.cpp
+++ b/tests/beman/inplace_vector/inplace_vector.test.cpp
@@ -2,7 +2,7 @@
 #include <beman/inplace_vector/inplace_vector.hpp>
 #include <cassert>
 
-using namespace beman;
+using namespace beman::inplace_vector;
 
 template <typename T> constexpr void test() {
   using vec = inplace_vector<T, 42>;

--- a/tests/beman/inplace_vector/ref_impl.test.cpp
+++ b/tests/beman/inplace_vector/ref_impl.test.cpp
@@ -65,31 +65,32 @@ static constexpr void __assert_failure(char const *__file, int __line,
   }
 #endif
 
-template struct beman::details::inplace_vector::storage::zero_sized<int>;
-template struct beman::details::inplace_vector::storage::trivial<int, 10>;
-template struct beman::details::inplace_vector::storage::non_trivial<
+template struct beman::inplace_vector::details::storage::zero_sized<int>;
+template struct beman::inplace_vector::details::storage::trivial<int, 10>;
+template struct beman::inplace_vector::details::storage::non_trivial<
     std::unique_ptr<int>, 10>;
 
-template struct beman::details::inplace_vector::storage::zero_sized<const int>;
-template struct beman::details::inplace_vector::storage::trivial<const int, 10>;
-template struct beman::details::inplace_vector::storage::non_trivial<
+template struct beman::inplace_vector::details::storage::zero_sized<const int>;
+template struct beman::inplace_vector::details::storage::trivial<const int, 10>;
+template struct beman::inplace_vector::details::storage::non_trivial<
     const std::unique_ptr<int>, 10>;
 
 // empty:
-template struct beman::inplace_vector<int, 0>;
+template struct beman::inplace_vector::inplace_vector<int, 0>;
 
 // trivial non-empty:
-template struct beman::inplace_vector<int, 1>;
-template struct beman::inplace_vector<int, 2>;
-template struct beman::inplace_vector<const int, 3>;
+template struct beman::inplace_vector::inplace_vector<int, 1>;
+template struct beman::inplace_vector::inplace_vector<int, 2>;
+template struct beman::inplace_vector::inplace_vector<const int, 3>;
 
 // non-trivial
-template struct beman::inplace_vector<std::string, 3>;
-template struct beman::inplace_vector<const std::string, 3>;
+template struct beman::inplace_vector::inplace_vector<std::string, 3>;
+template struct beman::inplace_vector::inplace_vector<const std::string, 3>;
 
 // move-only:
-template struct beman::inplace_vector<std::unique_ptr<int>, 3>;
-template struct beman::inplace_vector<const std::unique_ptr<int>, 3>;
+template struct beman::inplace_vector::inplace_vector<std::unique_ptr<int>, 3>;
+template struct beman::inplace_vector::inplace_vector<
+    const std::unique_ptr<int>, 3>;
 
 struct tint {
   std::size_t i;
@@ -110,10 +111,13 @@ static_assert(std::is_trivial<tint>{} && std::is_copy_constructible<tint>{} &&
               "");
 
 // Explicit instantiations
-template struct beman::inplace_vector<tint, 0>; // trivial empty
-template struct beman::inplace_vector<tint, 1>; // trivial non-empty
-template struct beman::inplace_vector<tint, 2>; // trivial non-empty
-template struct beman::inplace_vector<tint, 3>; // trivial non-empty
+template struct beman::inplace_vector::inplace_vector<tint, 0>; // trivial empty
+template struct beman::inplace_vector::inplace_vector<tint,
+                                                      1>; // trivial non-empty
+template struct beman::inplace_vector::inplace_vector<tint,
+                                                      2>; // trivial non-empty
+template struct beman::inplace_vector::inplace_vector<tint,
+                                                      3>; // trivial non-empty
 
 struct moint final {
   std::size_t i = 0;
@@ -144,7 +148,8 @@ static_assert(!std::is_trivial<moint>{} and
 // template struct std::inplace_vector<moint, 2>;
 // template struct std::inplace_vector<moint, 3>;
 
-template <typename T, std::size_t N> using vector = beman::inplace_vector<T, N>;
+template <typename T, std::size_t N>
+using vector = beman::inplace_vector::inplace_vector<T, N>;
 
 class non_copyable {
   int i_;
@@ -353,10 +358,10 @@ template <typename T, std::size_t N> void test_all() {
 
 int main() {
   { // storage
-    using beman::details::inplace_vector::storage::non_trivial;
-    using beman::details::inplace_vector::storage::storage_for;
-    using beman::details::inplace_vector::storage::trivial;
-    using beman::details::inplace_vector::storage::zero_sized;
+    using beman::inplace_vector::details::storage::non_trivial;
+    using beman::inplace_vector::details::storage::storage_for;
+    using beman::inplace_vector::details::storage::trivial;
+    using beman::inplace_vector::details::storage::zero_sized;
 
     static_assert(std::is_same<storage_for<int, 0>, zero_sized<int>>{});
     static_assert(std::is_same<storage_for<int, 10>, trivial<int, 10>>{});

--- a/tests/beman/inplace_vector/size_n_data.test.cpp
+++ b/tests/beman/inplace_vector/size_n_data.test.cpp
@@ -43,6 +43,27 @@ TYPED_TEST(SizeNCapacity, ResizeDown) {
   EXPECT_EQ(device, IV{});
 }
 
+TYPED_TEST(SizeNCapacity, ResizeDownWValue) {
+  // constexpr void resize(size_type sz, const T& value);
+  // Preconditions: T is Cpp17DefaultInsertable into inplace_vector.
+  // Effects: If sz < size(), erases the last size() - sz elements from the
+  // sequence. Otherwise, appends sz - size() default-inserted elements to the
+  // sequence. Remarks: If an exception is thrown, there are no effects on
+  // *this.
+
+  using IV = TestFixture::IV;
+  using T = TestFixture::T;
+
+  auto device = this->unique();
+
+  auto mid_size = std::midpoint(0ul, device.size());
+  device.resize(mid_size, T{});
+  EXPECT_EQ(device, IV(device.begin(), device.begin() + mid_size));
+
+  device.resize(0, T{});
+  EXPECT_EQ(device, IV{});
+}
+
 TYPED_TEST(SizeNCapacity, ResizeUp) {
   // constexpr void resize(size_type sz);
   // Preconditions: T is Cpp17DefaultInsertable into inplace_vector.
@@ -87,6 +108,52 @@ TYPED_TEST(SizeNCapacity, ResizeUp) {
 
   IV before_resize(device);
   SAFE_EXPECT_THROW(device.resize(device.capacity() + 1), std::bad_alloc);
+  EXPECT_EQ(device, before_resize);
+}
+
+TYPED_TEST(SizeNCapacity, ResizeUpWValue) {
+  // constexpr void resize(size_type sz, const T& value);
+  // Preconditions: T is Cpp17DefaultInsertable into inplace_vector.
+  // Effects: If sz < size(), erases the last size() - sz elements from the
+  // sequence. Otherwise, appends sz - size() default-inserted elements to the
+  // sequence. Remarks: If an exception is thrown, there are no effects on
+  // *this.
+
+  using IV = TestFixture::IV;
+  using T = TestFixture::T;
+
+  IV device;
+
+  SAFE_EXPECT_THROW(device.resize(device.capacity() + 1, T{}), std::bad_alloc);
+  EXPECT_EQ(device, IV{});
+
+  if (device.capacity() == 0)
+    return;
+
+  // Trying to pollute device[0]
+  device.push_back(T{255});
+  device.pop_back();
+  EXPECT_TRUE(device.empty());
+
+  device.resize(1, T{0});
+  EXPECT_EQ(device.size(), 1);
+  if (std::is_same_v<T, NonTriviallyDefaultConstructible> ||
+      std::is_same_v<T, NonTrivial>)
+    EXPECT_EQ(device, IV{T{0}});
+
+  T front{341};
+  device[0] = front;
+  device.resize(device.capacity(), front);
+  EXPECT_EQ(device[0], front);
+
+  if (std::is_same_v<T, NonTriviallyDefaultConstructible> ||
+      std::is_same_v<T, NonTrivial>) {
+    IV expected(device.capacity(), T{341});
+    EXPECT_EQ(device, expected);
+  }
+
+  IV before_resize(device);
+  SAFE_EXPECT_THROW(device.resize(device.capacity() + 1, T{}), std::bad_alloc);
   EXPECT_EQ(device, before_resize);
 }
 


### PR DESCRIPTION
close #85 

namespace changes:
`beman::inplace_vector<..>` moved to `beman::inplace_vector::inplace_vector<..>`  
`beman::details::inplace_vector` moved to `beman::inplace_vector::details`   
`beman::freestanding::inplace_vector` to `beman::inplace_vector::freestanding`  
`beman::from_range` polyfill moved to `beman::inplace_vector::details::from_range`
`beman::erase` moved to `beman::inplace_vector::erase`

this will couse some minor inconvenience for anyone who is already using the library, but I do believe we should fix the namespace for consistency

also add missing test case for resize with init value #89