### PR TITLE
Removed error in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# beman.inplace\_vector: Dynamically-resizable vector with fixed capacity
+# beman.inplace_vector: Dynamically-resizable vector with fixed capacity
 
 <!--
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception


### PR DESCRIPTION
Issue: https://github.com/orgs/bemanproject/projects/8/views/1?pane=issue&itemId=179205907&issue=bemanproject%7Cbeman-tidy%7C257

Before the PR:
```
Running check [Recommendation][readme.title] ...
[warning][readme.title]: The first line of the file 'README.md' is invalid. It should start with '# beman.inplace_vector: <short_description>'.
        check [Recommendation][readme.title] ... failed
```
The check was failing at this line:
```
# beman.inplace\_vector: Dynamically-resizable vector with fixed capacity
```