### PR TITLE
Add gcc15,clang21,clang22 workflows to ci

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -34,7 +34,7 @@ jobs:
       matrix_config: >
         {
           "gcc": [
-            { "versions": ["14"],
+            { "versions": ["14", "15"],
               "tests": [
                 { "cxxversions": ["c++23", "c++20"],
                   "tests": [
@@ -60,7 +60,7 @@ jobs:
             }
           ],
           "clang": [
-            { "versions": ["20"],
+            { "versions": ["20", "21", "22"],
               "tests": [
                 { "cxxversions": ["c++23", "c++20"],
                   "tests": [


### PR DESCRIPTION
testing inplace_vector with newer compiler version

also running Asan and Tsan for all buils feels wasteful and hella slow, furthermore I dont really see a point of running Tsan for inplace_vector at all...

