### PR TITLE
Expand CI matrix

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -34,44 +34,87 @@ jobs:
       matrix_config: >
         {
           "gcc": [
-            { "versions": ["14"],
+            { "versions": ["15"],
               "tests": [
-                { "cxxversions": ["c++23", "c++20"],
+                { "cxxversions": ["c++26"],
                   "tests": [
                     { "stdlibs": ["libstdc++"],
                       "tests": [
-                        "Release.Default",
-                        "Release.TSan", "Release.ASan",
-                        "Release.-DBEMAN_INPLACE_VECTOR_NO_EXCEPTIONS=ON"
+                        "Debug.Default", "Release.Default",
+                        "Release.MaxSan",
+                        "Debug.Coverage", "Release.-DBEMAN_INPLACE_VECTOR_NO_EXCEPTIONS=ON"
                       ]
                     }
                   ]
                 },
-                { "cxxversions": ["c++20"],
-                  "tests": [
-                    { "stdlibs": ["libstdc++"],
-                      "tests": [
-                        "Release.Dynamic"
-                      ]
-                    }
-                  ]
+                { "cxxversions": ["c++23", "c++20"],
+                  "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
+                }
+              ]
+            },
+            { "versions": ["14", "13"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++23", "c++20"],
+                  "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
             }
           ],
           "clang": [
-            { "versions": ["20"],
+            { "versions": ["22"],
               "tests": [
-                { "cxxversions": ["c++23", "c++20"],
+                {"cxxversions": ["c++26"],
                   "tests": [
-                    { "stdlibs": ["libstdc++"],
+                    { "stdlibs": ["libstdc++", "libc++"],
                       "tests": [
-                        "Release.Default",
-                        "Release.TSan", "Release.ASan",
-                        "Release.-DBEMAN_INPLACE_VECTOR_NO_EXCEPTIONS=ON"
+                        "Debug.Default", "Release.Default",
+                        "Release.MaxSan", "Release.-DBEMAN_INPLACE_VECTOR_NO_EXCEPTIONS=ON"
                       ]
                     }
                   ]
+                },
+                { "cxxversions": ["c++23", "c++20"],
+                  "tests": [
+                    {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
+                  ]
+                }
+              ]
+            },
+            { "versions": ["21", "20", "19"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++23", "c++20"],
+                  "tests": [
+                    {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
+                  ]
+                }
+              ]
+            },
+            { "versions": ["18"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++23", "c++20"],
+                  "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]
+                },
+                { "cxxversions": ["c++23", "c++20"],
+                  "tests": [{"stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
+                }
+              ]
+            },
+            { "versions": ["17"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++23", "c++20"],
+                  "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]
+                },
+                { "cxxversions": ["c++20"],
+                  "tests": [{"stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
+                }
+              ]
+            }
+          ],
+          "appleclang": [
+            { "versions": ["latest"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++23", "c++20"],
+                  "tests": [{ "stdlibs": ["libc++"], "tests": ["Release.Default"]}]
                 }
               ]
             }

--- a/README.md
+++ b/README.md
@@ -130,10 +130,15 @@ You can disable building tests by setting CMake option `BEMAN_INPLACE_VECTOR_BUI
 
 ### Supported Platforms
 
-| Compiler | Version | C++ Standards | Standard Library |
-|----------|---------|---------------|------------------|
-| GCC      | 14      | C++23, C++20  | libstdc++        |
-| Clang    | 20      | C++23, C++20  | libstdc++        |
+| Compiler   | Version | C++ Standards | Standard Library  |
+|------------|---------|---------------|-------------------|
+| GCC        | 15-13   | C++26-C++20   | libstdc++         |
+| Clang      | 22-19   | C++26-C++20   | libstdc++, libc++ |
+| Clang      | 18      | C++26-C++20   | libc++            |
+| Clang      | 18      | C++23, C++20  | libstdc++         |
+| Clang      | 17      | C++26-C++20   | libc++            |
+| Clang      | 17      | C++20         | libstdc++         |
+| AppleClang | latest  | C++26-C++20   | libc++            |
 
 ## Development
 


### PR DESCRIPTION
Previously, the CI matrix had an unnecessarily small set of supported platforms. This commit expands it to the same set of compilers that exemplar tests, except for:

- MSVC builds
- C++17 builds
- GCC 11/12
- Werror builds
- TSan builds

Fixes: https://github.com/bemanproject/inplace_vector/issues/131, https://github.com/bemanproject/inplace_vector/issues/132, https://github.com/bemanproject/inplace_vector/issues/133

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
