### PR TITLE
Expose BEMAN_INPLACE_VECTOR_NO_EXCEPTIONS as a vcpkg feature

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   beman-submodule-check:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.6.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.7.0
 
   preset-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.6.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.7.0
     with:
       matrix_config: >
         [
@@ -29,7 +29,7 @@ jobs:
         ]
 
   build-and-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.6.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.7.0
     with:
       matrix_config: >
         {
@@ -122,11 +122,16 @@ jobs:
         }
 
   vcpkg-ci:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-ci.yml@1.6.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-ci.yml@1.7.0
     with:
       port_name: beman-inplace-vector
+      feature_combinations: |
+        [
+          {"features": {}},
+          {"features": {"no-exceptions": true}}
+        ]
 
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
     if: failure() && github.event_name == 'schedule'
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.6.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.7.0

--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -16,4 +16,4 @@ permissions:
 
 jobs:
   pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.6.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.7.0

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   auto-update-pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.6.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.7.0
     secrets:
       APP_ID: ${{ secrets.AUTO_PR_BOT_APP_ID }}
       PRIVATE_KEY: ${{ secrets.AUTO_PR_BOT_PRIVATE_KEY }}

--- a/.github/workflows/vcpkg-release.yml
+++ b/.github/workflows/vcpkg-release.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 jobs:
   vcpkg-release:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-release.yml@1.6.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-release.yml@1.7.0
     with:
       port_name: beman-inplace-vector
     secrets:

--- a/port/portfile.cmake.in
+++ b/port/portfile.cmake.in
@@ -6,9 +6,16 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        no-exceptions   BEMAN_INPLACE_VECTOR_NO_EXCEPTIONS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DBEMAN_INPLACE_VECTOR_BUILD_TESTS=OFF
         -DBEMAN_INPLACE_VECTOR_BUILD_EXAMPLES=OFF
 )

--- a/port/vcpkg.json.in
+++ b/port/vcpkg.json.in
@@ -13,5 +13,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "no-exceptions": {
+      "description": "Replace throw with abort (BEMAN_INPLACE_VECTOR_NO_EXCEPTIONS=ON)"
+    }
+  }
 }


### PR DESCRIPTION
Add a no-exceptions feature to the port manifest and translate it via vcpkg_check_features into the CMake option, so consumers can install beman-inplace-vector[no-exceptions] to get the abort-on-overflow build.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
