### PR TITLE
fix: add license to examples

### DIFF
--- a/examples/capacity.cpp
+++ b/examples/capacity.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <beman/inplace_vector/inplace_vector.hpp>
 
 #include <iostream>

--- a/examples/comparison.cpp
+++ b/examples/comparison.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <array>
 #include <beman/inplace_vector/inplace_vector.hpp>
 

--- a/examples/fallible.cpp
+++ b/examples/fallible.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <beman/inplace_vector/inplace_vector.hpp>
 
 #include <iostream>


### PR DESCRIPTION
This pull request adds SPDX license identifiers to the top of several example source files to clarify their licensing. No other code changes were made.

Licensing updates:

* Added `// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception` to the top of `examples/capacity.cpp`, `examples/comparison.cpp`, and `examples/fallible.cpp` to clearly state the license for these files. [[1]](diffhunk://#diff-a08141147d4f53a4654322b0a3f33c0278e1aad7eaac08bc849077c8af084d70R1-R2) [[2]](diffhunk://#diff-9e84ed57d32c75b5bd8107485c98a70f9a359a70f6d36d997be0b715cde281eeR1-R2) [[3]](diffhunk://#diff-0c6bad961b376375b2cc39f11a69bd0acf0f1d6658e3178ff39096cd7819827aR1-R2)