### PR TITLE
Enable beman-tidy (--require-all mode) into beman.inplace_vector

### DIFF
--- a/.beman-tidy.yaml
+++ b/.beman-tidy.yaml
@@ -4,7 +4,5 @@
 # Check documentation for beman-tidy here:
 # https://github.com/bemanproject/beman-tidy/blob/main/README.md
 
-disabled_rules:
-    # None
-ignored_paths:
-    # None
+disabled_rules: []
+ignored_paths: []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,5 +46,6 @@ repos:
     rev: v0.5.1
     hooks:
     - id: beman-tidy
+      args: [".", "--verbose", "--require-all"]
 
 exclude: 'cookiecutter/|infra/|port/'

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 [![Lint Check (pre-commit)](https://github.com/bemanproject/inplace_vector/actions/workflows/pre-commit-check.yml/badge.svg)](https://github.com/bemanproject/inplace_vector/actions/workflows/pre-commit-check.yml)
 [![Coverage](https://coveralls.io/repos/github/bemanproject/inplace_vector/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/inplace_vector?branch=main)
 ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
+[![Compiler Explorer Example](https://img.shields.io/badge/Try%20it%20on%20Compiler%20Explorer-grey?logo=compilerexplorer&logoColor=67c52a)](https://godbolt.org/z/T15TxaTrf)
 <!-- markdownlint-restore -->
 
 **Implements**: [`inplace_vector` (P0843R14)](https://wg21.link/P0843R14).

--- a/examples/capacity.cpp
+++ b/examples/capacity.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <beman/inplace_vector/inplace_vector.hpp>
 
 #include <iostream>

--- a/examples/comparison.cpp
+++ b/examples/comparison.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <array>
 #include <beman/inplace_vector/inplace_vector.hpp>
 

--- a/examples/fallible.cpp
+++ b/examples/fallible.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <beman/inplace_vector/inplace_vector.hpp>
 
 #include <iostream>


### PR DESCRIPTION
Issue: bemanproject/beman-tidy#257

Enable `beman-tidy --require-all` on CI for `beman.inplace_vector`, following the same approach as bemanproject/indices_view#14.

CODEOWNERS approval: @camio replied "No objection from me" on the `--require-all` proposal in the issue.

## Changes
- Enable `--require-all` in `.pre-commit-config.yaml`
- Add Compiler Explorer badge to README (`https://godbolt.org/z/T15TxaTrf`)
- Add SPDX license headers to new example files flagged by `file.license_id`
- Fix `.beman-tidy.yaml` to use empty lists instead of YAML `null` (required for beman-tidy v0.5.1)

## Test plan
- [x] `beman-tidy . --verbose --require-all` passes locally (100% requirement coverage)
- [x] CI pre-commit check passes