### PR TITLE
Remove try_append_range

### DIFF
--- a/include/beman/inplace_vector/inplace_vector.hpp
+++ b/include/beman/inplace_vector/inplace_vector.hpp
@@ -355,18 +355,6 @@ public:
     return unchecked_emplace_back(std::forward<T &&>(x));
   }
 
-  template <details::container_compatible_range<T> R>
-  constexpr std::ranges::borrowed_iterator_t<R> try_append_range(R &&rg)
-    requires(std::constructible_from<T, std::ranges::range_reference_t<R>>)
-  {
-    auto it = std::ranges::begin(rg);
-    const auto end = std::ranges::end(rg);
-    for (; size() != capacity() && it != end; ++it) {
-      unchecked_emplace_back(*it);
-    }
-    return it;
-  }
-
   constexpr iterator erase(const_iterator first, const_iterator last)
     requires(std::movable<T>)
   {

--- a/tests/beman/inplace_vector/constexpr.test.cpp
+++ b/tests/beman/inplace_vector/constexpr.test.cpp
@@ -224,7 +224,6 @@ template <typename IV> constexpr void test_modifiers() {
     v.try_emplace_back(20);
     v.try_push_back(arr[0]);
     v.try_push_back(T(20));
-    // v.try_append_range(arr);
   }
 
   {
@@ -347,7 +346,6 @@ template <typename T> constexpr void speical_test_empty() {
     v.try_emplace_back(50);
     v.try_push_back(T(50));
     v.try_push_back(arr[0]);
-    // v.try_append_range(arr);
     v.clear();
   }
   {

--- a/tests/beman/inplace_vector/modifiers.test.cpp
+++ b/tests/beman/inplace_vector/modifiers.test.cpp
@@ -589,63 +589,6 @@ TYPED_TEST(Modifiers, TryPushBackRV) {
   }
 }
 
-TYPED_TEST(Modifiers, TryAppendRanges) {
-  // template<container-compatible-range<T> R>
-  // constexpr ranges::borrowed_iterator_t<R> try_append_range(R&& rg);
-  //
-  // Preconditions: value_type is Cpp17EmplaceConstructible into inplace_vector
-  // from *ranges::begin(rg).
-  //
-  // Effects: Appends copies of initial elements
-  // in rg before end(), until all elements are inserted or size() == capacity()
-  // is true. Each iterator in the range rg is dereferenced at most once.
-  //
-  // Returns: An iterator pointing to the first element of rg that was not
-  // inserted into *this, or ranges::end(rg) if no such element exists.
-  // Complexity: Linear in the number of elements inserted.
-  //
-  // Remarks: Let n be the value of size() prior to this call. If an exception
-  // is thrown after the insertion of k elements, then size() equals n + k ,
-  // elements in the range begin() + [0, n) are not modified, and elements in
-  // the range begin() + [n, n + k) correspond to the inserted elements.
-
-  using IV = TestFixture::IV;
-  using T = TestFixture::T;
-  using size_type = IV::size_type;
-
-  IV device;
-  auto reference = this->unique();
-
-  device.try_append_range(reference | std::views::take(0));
-  EXPECT_EQ(device, IV());
-  device.clear();
-
-  EXPECT_EQ(device.try_append_range(reference), reference.end());
-  EXPECT_EQ(device, reference);
-  EXPECT_EQ(device.try_append_range(reference), reference.begin());
-  device.clear();
-
-  auto range = std::array<T, IV::capacity() + 1>{};
-  std::copy_n(reference.begin(), IV::capacity(), range.begin());
-  EXPECT_EQ(device.try_append_range(range), range.end() - 1);
-  EXPECT_EQ(device, reference);
-  device.clear();
-
-  auto half_size = std::midpoint(size_type(0), reference.size());
-  EXPECT_EQ(device.try_append_range(reference | std::views::take(half_size)),
-            reference.begin() + half_size);
-  EXPECT_EQ(device.try_append_range(reference | std::views::drop(half_size)),
-            reference.end());
-  EXPECT_EQ(device, reference);
-
-  device.clear();
-
-  EXPECT_EQ(device.try_append_range(reference | std::views::drop(half_size)),
-            reference.end());
-  EXPECT_EQ(device.try_append_range(reference), reference.begin() + half_size);
-  device.clear();
-}
-
 TYPED_TEST(Modifiers, UncheckedEmplacedBack) {
   // template<class... Args>
   // constexpr reference unchecked_emplace_back(Args&&... args);

--- a/tests/beman/inplace_vector/noexceptions.test.cpp
+++ b/tests/beman/inplace_vector/noexceptions.test.cpp
@@ -32,8 +32,6 @@ TYPED_TEST(NoExceptions, NonThrowing) {
 
   EXPECT_EQ(device.try_emplace_back(T{}), nullptr);
   EXPECT_EQ(device.try_push_back(T{}), nullptr);
-  auto range = std::array<T, 1>{};
-  EXPECT_EQ(device.try_append_range(range), range.begin());
 
   IV sanitycheck = this->unique();
   EXPECT_EQ(sanitycheck.size(), IV::capacity());


### PR DESCRIPTION
<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->

Closes #118 as `try_append_range` has been removed from in C++26.